### PR TITLE
Added keepRepeatCommandNames option to .toString() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ generic curves (`Q`/`q`/`C`/`c`).
 Replaces all arcs with bezier curves.
 
 
-### .toString() -> string
+### .toString([keepRepeatCommandNames]) -> string
 
 Returns final path string.
+
+If the first parameter is set to `true`, it will disable optimizing for repeated command names.
 
 
 ### .round(precision) -> self

--- a/lib/svgpath.js
+++ b/lib/svgpath.js
@@ -179,7 +179,7 @@ SvgPath.prototype.__evaluateStack = function () {
 
 // Convert processed SVG Path back to string
 //
-SvgPath.prototype.toString = function () {
+SvgPath.prototype.toString = function (keepRepeatCommandNames) {
   var elements = [], skipCmd;
 
   this.__evaluateStack();
@@ -187,7 +187,7 @@ SvgPath.prototype.toString = function () {
   for (var i = 0; i < this.segments.length; i++) {
     // remove repeating commands names
     skipCmd = i > 0 && (this.segments[i][0] === this.segments[i - 1][0]);
-    elements = elements.concat(skipCmd ? this.segments[i].slice(1) : this.segments[i]);
+    elements = elements.concat(!keepRepeatCommandNames && skipCmd ? this.segments[i].slice(1) : this.segments[i]);
   }
 
   return elements.join(' ')

--- a/test/api.js
+++ b/test/api.js
@@ -529,4 +529,20 @@ describe('API', function () {
       );
     });
   });
+
+  describe('output path string', function () {
+    it('optimizes repeat command names by default', function () {
+      assert.equal(
+        svgpath('M 0 0 M 100 0 M 100 100 M 0 100').toString(),
+        'M0 0 100 0 100 100 0 100'
+      );
+    });
+
+    it('keeps repeat command names with keepRepeatCommandNames option', function () {
+      assert.equal(
+        svgpath('M 0 0 M 100 0 M 100 100 M 0 100').toString(true),
+        'M0 0M100 0M100 100M0 100'
+      );
+    });
+  });
 });


### PR DESCRIPTION
With this PR I've added the ability to drop the optimization regarding repeat command names in the string output. 

I also wanted to start a discussion on whether this is the right approach here. As per the [SVG 1.2 spec](http://www.w3.org/TR/SVGTiny12/paths.html#PathDataMovetoCommands) (SVG 2 is similar): 

> If a 'moveto' is followed by multiple pairs of coordinates, the subsequent pairs shall be treated as implicit 'lineto' commands.

So it's not correct to automatically transform `M 10 10 M 10 100 M 100 100 M 100 10 Z` to `M 10 10 10 100 100 100 100 10 Z`, as seen in this example (notice the difference in rendering): http://jsfiddle.net/u0eym6d7/

While it would be better to treat all the specific cases where removing repeat command names does not result in equivalent paths, this is a quick fix to disable that optimization.

__Edit:__ I fixed it through the extra parameter so that existing behavior is not changed. I've checked the SVG spec and the M seems to be the only command affected by this, so the alternative can be changing the condition to:
`skipCmd = i > 0 && (this.segments[i][0] === this.segments[i - 1][0] && this.segments[i][0].toLowerCase() !== 'm');`

Waiting for your thoughts on this :-)