### PR TITLE
Add skewX/Y methods to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Rotate path to `angle` degree around (rx, ry) point. If rotation center not set,
 (0, 0) used. The same as SVG `rotate` transformation.
 
 
+### .skewX(angle) -> self
+
+Skews path along the x axis by `angle` degrees. The same as SVG `skewX` 
+transformation.
+
+
+### .skewY(angle) -> self
+
+Skews path along the y axis by `angle` degrees. The same as SVG `skewY` 
+transformation.
+
+
 ### .matrix([ m1, m2, m3, m4, m5, m6 ]) -> self
 
 Apply 2x3 affine transform matrix to path. Params - array. The same as SVG

--- a/lib/svgpath.js
+++ b/lib/svgpath.js
@@ -216,6 +216,19 @@ SvgPath.prototype.rotate = function (angle, rx, ry) {
   return this;
 };
 
+// Skew path along x axis
+//
+SvgPath.prototype.skewX = function (angle) {
+  this.__stack.push(matrix().skewX(angle));
+  return this;
+};
+
+// Skew path along y axis
+//
+SvgPath.prototype.skewY = function (angle) {
+  this.__stack.push(matrix().skewY(angle));
+  return this;
+};
 
 // Apply matrix transform (array of 6 elements)
 //


### PR DESCRIPTION
SVG defines six transformations: translate, rotate, scale, matrix, skewX and skewY. I thought it would be sensible and useful to have all of these in the API.