### PR TITLE
define rel type for usage in typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ declare module "svgpath" {
     (path: string): SvgPath;
     new (path: string): SvgPath;
     abs(): SvgPath;
+    rel(): SvgPath;
     scale(sx: number, sy?: number): SvgPath;
     translate(x: number, y?: number): SvgPath;
     rotate(angle: number, rx?: number, ry?: number): SvgPath;


### PR DESCRIPTION
Just add a type for **rel** method in **d.ts** file, and it can fix **Type Missing** problem when using **rel** method in typescript. 