### PR TITLE
add skipStringOptimizations options to toString

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ generic curves (`Q`/`q`/`C`/`c`).
 Replaces all arcs with bezier curves.
 
 
-### .toString() -> string
+### .toString(options) -> string
 
 Returns final path string.
+
+When optional options parameter `skipStringOptimizations` is set to true it will skip removing repeating commands names and whitespaces. This can be usefull to skip for large paths.
+Usage: `.toString({ skipStringOptimizations: true });`
 
 
 ### .round(precision) -> self

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module "svgpath" {
     transform(str: string): SvgPath;
     unshort(): SvgPath;
     unarc(): SvgPath;
-    toString(options: { skipStringOptimizations: boolean }): string;
+    toString(options?: { skipStringOptimizations: boolean }): string;
     round(precision: number): SvgPath;
     iterate(iterator: (segment: any[], index: number, x: number, y: number) => void, keepLazyStack?: boolean): SvgPath;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module "svgpath" {
     transform(str: string): SvgPath;
     unshort(): SvgPath;
     unarc(): SvgPath;
-    toString(): string;
+    toString(options: { skipStringOptimizations: boolean }): string;
     round(precision: number): SvgPath;
     iterate(iterator: (segment: any[], index: number, x: number, y: number) => void, keepLazyStack?: boolean): SvgPath;
   }

--- a/lib/svgpath.js
+++ b/lib/svgpath.js
@@ -190,8 +190,9 @@ SvgPath.prototype.toString = function (options) {
   this.__evaluateStack();
 
   if (options && options.skipStringOptimizations) {
-    return this.segments.reduce((previous, current) => {
-      return previous += `${current.join(" ")}`;
+    return this.segments.reduce(function (previous, current) {
+      previous += current.join(' ');
+      return previous;
     }, '');
   }
 

--- a/lib/svgpath.js
+++ b/lib/svgpath.js
@@ -186,10 +186,16 @@ SvgPath.prototype.__evaluateStack = function () {
 
 // Convert processed SVG Path back to string
 //
-SvgPath.prototype.toString = function () {
-  var elements = [], skipCmd, cmd;
-
+SvgPath.prototype.toString = function (options) {
   this.__evaluateStack();
+
+  if (options && options.skipStringOptimizations) {
+    return this.segments.reduce((previous, current) => {
+      return previous += `${current.join(" ")}`;
+    }, '');
+  }
+
+  var elements = [], skipCmd, cmd;
 
   for (var i = 0; i < this.segments.length; i++) {
     // remove repeating commands names


### PR DESCRIPTION
I'm optimizing the performance of a project I'm working on. It contains large paths (for example with a length of 160k). When skipping the string optimizations in toString I can see performance improvements around 7-11x. When having multiple of these large paths this adds up.

I made a simple example here: https://codepen.io/klaasvaak/pen/dyVjPje?editors=1011

Let me know if you have concerns about skipping these string optimizations.