### PR TITLE
return broken path data until the first error

### DIFF
--- a/lib/path_parse.js
+++ b/lib/path_parse.js
@@ -242,6 +242,7 @@ function scanSegment(state) {
       else scanParam(state);
 
       if (state.err.length) {
+        finalizeSegment(state);
         return;
       }
       state.data.push(state.param);
@@ -291,11 +292,7 @@ module.exports = function pathParse(svgPath) {
     scanSegment(state);
   }
 
-  if (state.err.length) {
-    state.result = [];
-
-  } else if (state.result.length) {
-
+  if (state.result.length) {
     if ('mM'.indexOf(state.result[0][0]) < 0) {
       state.err = 'SvgPath: string should start with `M` or `m`';
       state.result = [];

--- a/test/path_parse.js
+++ b/test/path_parse.js
@@ -68,4 +68,16 @@ describe('Path parse', function () {
     assert.strictEqual(svgpath('M0 .e3').err, 'SvgPath: invalid float exponent (at pos 4)');
     assert.strictEqual(svgpath('M0 0a2 2 2 2 2 2 2').err, 'SvgPath: arc flag can be 0 or 1 only (at pos 11)');
   });
+
+  it('keeps valid commands', function () {
+    assert.strictEqual(svgpath('M0 0G 1').toString(), 'M0 0');
+    assert.strictEqual(svgpath('z').toString(), '');
+    assert.strictEqual(svgpath('M0 0L+').toString(), 'M0 0');
+    assert.strictEqual(svgpath('M0 0L00').toString(), 'M0 0');
+    assert.strictEqual(svgpath('M0 0L0e').toString(), 'M0 0');
+    assert.strictEqual(svgpath('M0 0L0').toString(), 'M0 0');
+    assert.strictEqual(svgpath('M0,0,').toString(), 'M0 0');
+    assert.strictEqual(svgpath('M0 0L0 .e3').toString(), 'M0 0');
+    assert.strictEqual(svgpath('M0 0a2 2 2 2 2 2 2').toString(), 'M0 0');
+  });
 });


### PR DESCRIPTION
According to [the SVG specs][1], "*the SVG user agent shall render a ‘path’ element up to (but not including) the path command containing the first error in the path data specification*".

Before this PR when an error was met, the full segments list was discarded, e.g the input `'M10 10L20 20 30'` would generate the empty string `''`. After this PR, it generates the string `'M10 10L20 20'` as expected by the specs.

Note that all major web-browsers do this in their SVG implementation https://jsfiddle.net/mgfw1r4j/ .

[1]: https://svgwg.org/svg2-draft/paths.html#PathDataErrorHandling